### PR TITLE
Fix text alignment on block stat

### DIFF
--- a/src/components/BlockStats/BlockStats.js
+++ b/src/components/BlockStats/BlockStats.js
@@ -16,11 +16,13 @@ const BlockStatsCont = styled.div`
 
 const BlockStatCell = styled.span`
   align-self: center; 
+  text-align: right;
 `
 
 const DecoratedBlockStatCell = styled(BlockStatCell)`
   font-weight: ${metrics.fontWeight};
   margin-right: ${metrics.margin}rem;
+  text-align: left;
 `
 
 const BlockStatsColumn = styled.section`


### PR DESCRIPTION
Remove the following shift from some of last block stats:

![text-alignment](https://user-images.githubusercontent.com/1053622/73950514-5730dd00-48fc-11ea-93b6-cdd181e10e58.png)
 